### PR TITLE
Eliminating configuration under project#afterEvaluate block ... only adding task 'generateCandidKt' for the 'main' source set by default

### DIFF
--- a/src/main/kotlin/com/github/seniorjoinu/candid/plugin/CandidKtPlugin.kt
+++ b/src/main/kotlin/com/github/seniorjoinu/candid/plugin/CandidKtPlugin.kt
@@ -4,10 +4,10 @@ import org.gradle.api.NamedDomainObjectFactory
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-const val CANDIDKT_EXTENSION_NAME = "candid"
-const val CANDIDKT_GROUP_NAME = "candid"
-const val CANDIDKT_TASK_NAME = "generateCandidKt"
-const val CANDIDKT_TASK_DESTINATION_PREFIX = "generated/sources/candid/kotlin"
+const val CANDID_EXTENSION_NAME = "candid"
+const val CANDID_GROUP_NAME = "candid"
+const val CANDID_TASK_NAME = "generateCandid"
+const val CANDID_DESTINATION_PREFIX_KOTLIN = "generated/sources/candid/kotlin"
 
 /**
  * The Candid to Kotlin plugin.
@@ -15,7 +15,7 @@ const val CANDIDKT_TASK_DESTINATION_PREFIX = "generated/sources/candid/kotlin"
 abstract class CandidKtPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         // Add the extension object
-        project.extensions.create(CANDIDKT_EXTENSION_NAME, CandidKtExtension::class.java, project)
+        project.extensions.create(CANDID_EXTENSION_NAME, CandidKtExtension::class.java, project)
         project.candidExtension.apply {
             fun candidSourceSetContainer(factory: NamedDomainObjectFactory<CandidSourceSet>) = project.container(CandidSourceSet::class.java, factory)
 
@@ -35,10 +35,9 @@ abstract class CandidKtPlugin : Plugin<Project> {
 
     private fun registerSourceTask(project: Project, sourceSetName: String) = with(project.candidExtension) {
         val sourceSet = project.candidExtension.sourceSets.getByName(sourceSetName)
-        val taskName = if (sourceSetName == CandidSourceSet.SOURCE_SET_NAME_MAIN) CANDIDKT_TASK_NAME else CANDIDKT_TASK_NAME.replace("generate", "generate${sourceSetName.capitalize()}")
-        project.tasks.register(taskName, CandidKtTask::class.java) { candidKtTask ->
+        project.tasks.register(sourceSet.taskName, CandidKtTask::class.java) { candidKtTask ->
             candidKtTask.description = "Generates Kotlin sources from Candid language files resolved from the '$sourceSetName' Candid source set."
-            candidKtTask.group = CANDIDKT_GROUP_NAME
+            candidKtTask.group = CANDID_GROUP_NAME
             candidKtTask.sourceSetName = sourceSetName
             candidKtTask.genPackage.set(genPackage)
             candidKtTask.sourceSet.takeIf { it != sourceSet }?.dependsOn(sourceSet)

--- a/src/main/kotlin/com/github/seniorjoinu/candid/plugin/CandidSourceSet.kt
+++ b/src/main/kotlin/com/github/seniorjoinu/candid/plugin/CandidSourceSet.kt
@@ -25,7 +25,6 @@ interface CandidSourceSet : Named {
 
     companion object {
         const val SOURCE_SET_NAME_MAIN = "main"
-        const val SOURCE_SET_NAME_TEST = "test"
     }
 }
 

--- a/src/main/kotlin/com/github/seniorjoinu/candid/plugin/CandidSourceSet.kt
+++ b/src/main/kotlin/com/github/seniorjoinu/candid/plugin/CandidSourceSet.kt
@@ -10,7 +10,7 @@ import org.gradle.util.ConfigureUtil
 import java.io.File
 
 internal val Project.candidExtension: CandidKtExtension
-    get() = extensions.getByName(CANDIDKT_EXTENSION_NAME) as CandidKtExtension
+    get() = extensions.getByName(CANDID_EXTENSION_NAME) as CandidKtExtension
 
 interface CandidSourceSetContainer {
     val sourceSets: NamedDomainObjectContainer<CandidSourceSet>
@@ -19,6 +19,8 @@ interface CandidSourceSetContainer {
 interface CandidSourceSet : Named {
     val candid: SourceDirectorySet
     fun candid(configureClosure: Closure<Any?>): SourceDirectorySet
+
+    val taskName: String
 
     fun dependsOn(other: CandidSourceSet)
     val dependsOn: Set<CandidSourceSet>
@@ -68,13 +70,15 @@ internal class DefaultCandidSourceSet(
 
     override val candid: SourceDirectorySet = createDefaultSourceDirectorySet(project, name).apply {
         filter.include("**/*.did")
-        destinationDirectory.fileValue(project.buildDir.resolve("$CANDIDKT_TASK_DESTINATION_PREFIX/$name"))
+        destinationDirectory.fileValue(project.buildDir.resolve("$CANDID_DESTINATION_PREFIX_KOTLIN/$name"))
     }
 
 
     override fun candid(configureClosure: Closure<Any?>): SourceDirectorySet = candid.apply { ConfigureUtil.configure(configureClosure, this) }
 
     override fun getName(): String = displayName
+
+    override val taskName = if (name == CandidSourceSet.SOURCE_SET_NAME_MAIN) CANDID_TASK_NAME else CANDID_TASK_NAME.replace("generate", "generate${name.capitalize()}")
 
     override fun dependsOn(other: CandidSourceSet) {
         dependsOnSourceSetsImpl.add(other)

--- a/src/test/kotlin/com/github/seniorjoinu/candid/plugin/CandidKtPluginSpec.kt
+++ b/src/test/kotlin/com/github/seniorjoinu/candid/plugin/CandidKtPluginSpec.kt
@@ -44,31 +44,31 @@ class CandidKtPluginSpec : FreeSpec({
                 val arguments = listOf(taskName)
                 val result = build(projectDir.root, arguments)
                 result.task(":$taskName")?.outcome shouldBe TaskOutcome.SUCCESS
-                result.output shouldContain "${CANDIDKT_GROUP_NAME.capitalize()} tasks"
-                result.output shouldContain "$CANDIDKT_TASK_NAME - Generates Kotlin sources from Candid language files resolved from the 'main' Candid source set."
-                result.output shouldContain "generateTestCandidKt - Generates Kotlin sources from Candid language files resolved from the 'test' Candid source set."
+                result.output shouldContain "${CANDID_GROUP_NAME.capitalize()} tasks"
+                result.output shouldContain "$CANDID_TASK_NAME - Generates Kotlin sources from Candid language files resolved from the 'main' Candid source set."
+                result.output shouldContain "generateTestCandid - Generates Kotlin sources from Candid language files resolved from the 'test' Candid source set."
             }
-            "positive executing 'gradle help --task generateCandidKt'" - {
+            "positive executing 'gradle help --task generateCandid'" - {
                 val taskName = "help"
-                val arguments = listOf(taskName, "--task", CANDIDKT_TASK_NAME)
+                val arguments = listOf(taskName, "--task", CANDID_TASK_NAME)
                 val result = build(projectDir.root, arguments)
                 result.task(":$taskName")?.outcome shouldBe TaskOutcome.SUCCESS
-                result.output shouldContain "Detailed task information for $CANDIDKT_TASK_NAME"
-                result.output shouldContain "Path${System.lineSeparator()}     :$CANDIDKT_TASK_NAME"
+                result.output shouldContain "Detailed task information for $CANDID_TASK_NAME"
+                result.output shouldContain "Path${System.lineSeparator()}     :$CANDID_TASK_NAME"
                 result.output shouldContain "Description${System.lineSeparator()}     Generates Kotlin sources from Candid language files resolved from the 'main' Candid source set."
-                result.output shouldContain "Group${System.lineSeparator()}     $CANDIDKT_GROUP_NAME"
+                result.output shouldContain "Group${System.lineSeparator()}     $CANDID_GROUP_NAME"
             }
-            "positive executing 'gradle generateCandidKt' with defaults" - {
+            "positive executing 'gradle generateCandid' with defaults" - {
                 val didFile = createDidFile(projectDir.root, didName, "src", "main", "candid")
-                val ktFile = Paths.get(projectDir.root.canonicalPath, "build/$CANDIDKT_TASK_DESTINATION_PREFIX/main", "${didName}.did.kt").toFile()
-                val arguments = listOf(CANDIDKT_TASK_NAME, "--info", "--warning-mode", "all")
+                val ktFile = Paths.get(projectDir.root.canonicalPath, "build/$CANDID_DESTINATION_PREFIX_KOTLIN/main", "${didName}.did.kt").toFile()
+                val arguments = listOf(CANDID_TASK_NAME, "--info", "--warning-mode", "all")
                 val result = build(projectDir.root, arguments)
-                result.task(":$CANDIDKT_TASK_NAME")?.outcome shouldBe TaskOutcome.SUCCESS
+                result.task(":$CANDID_TASK_NAME")?.outcome shouldBe TaskOutcome.SUCCESS
                 ktFile.shouldExist()
                 ktFile.shouldNotHaveFileSize(0)
                 didFile.delete()
             }
-            "positive executing 'gradle generateCandidKt' with reconfigured destination directory" - {
+            "positive executing 'gradle generateCandid' with reconfigured destination directory" - {
                 val didFile = createDidFile(projectDir.root, didName, "src", "main", "candid")
                 val ktFile = Paths.get(projectDir.root.canonicalPath, "build/output", packageName.replace('.', '/'), "${didName}.did.kt").toFile()
                 buildFile.appendText("""
@@ -77,26 +77,26 @@ class CandidKtPluginSpec : FreeSpec({
                         genPackage = "$packageName"
                     }
                 """.trimIndent())
-                val arguments = listOf(CANDIDKT_TASK_NAME, "--info", "--warning-mode", "all")
+                val arguments = listOf(CANDID_TASK_NAME, "--info", "--warning-mode", "all")
                 val result = build(projectDir.root, arguments)
-                result.task(":$CANDIDKT_TASK_NAME")?.outcome shouldBe TaskOutcome.SUCCESS
+                result.task(":$CANDID_TASK_NAME")?.outcome shouldBe TaskOutcome.SUCCESS
                 ktFile.shouldExist()
                 ktFile.shouldNotHaveFileSize(0)
                 didFile.delete()
             }
-            "positive executing 'gradle generateCandidKt' with nested did files under different source directories" - {
+            "positive executing 'gradle generateCandid' with nested did files under different source directories" - {
                 val didFile = createDidFile(projectDir.root, didName, "src", "main", "candid", "tld", "d", "etc")
                 val otherDidFile = createDidFile(projectDir.root, "other-greet", "src", "other", "candid", "tld", "d", "etc")
-                val ktFile = Paths.get(projectDir.root.canonicalPath, "build/$CANDIDKT_TASK_DESTINATION_PREFIX/main", "tld/d/etc", "${didName}.did.kt").toFile()
-                val otherKtFile = Paths.get(projectDir.root.canonicalPath, "build/$CANDIDKT_TASK_DESTINATION_PREFIX/main", "tld/d/etc", "other-greet.did.kt").toFile()
+                val ktFile = Paths.get(projectDir.root.canonicalPath, "build/$CANDID_DESTINATION_PREFIX_KOTLIN/main", "tld/d/etc", "${didName}.did.kt").toFile()
+                val otherKtFile = Paths.get(projectDir.root.canonicalPath, "build/$CANDID_DESTINATION_PREFIX_KOTLIN/main", "tld/d/etc", "other-greet.did.kt").toFile()
                 buildFile.appendText("""
                     candid {
                         sourceSets.main.candid.srcDir 'src/other/candid'
                     }
                 """.trimIndent())
-                val arguments = listOf(CANDIDKT_TASK_NAME, "--info", "--warning-mode", "all")
+                val arguments = listOf(CANDID_TASK_NAME, "--info", "--warning-mode", "all")
                 val result = build(projectDir.root, arguments)
-                result.task(":$CANDIDKT_TASK_NAME")?.outcome shouldBe TaskOutcome.SUCCESS
+                result.task(":$CANDID_TASK_NAME")?.outcome shouldBe TaskOutcome.SUCCESS
                 ktFile.shouldExist()
                 otherKtFile.shouldExist()
                 ktFile.shouldNotHaveFileSize(0)
@@ -104,10 +104,10 @@ class CandidKtPluginSpec : FreeSpec({
                 didFile.delete()
                 otherDidFile.delete()
             }
-            "positive executing 'gradle generateIntegTestCandidKt'" - {
-                val taskName = "generateIntegTestCandidKt"
+            "positive executing 'gradle generateIntegTestCandid'" - {
+                val taskName = "generateIntegTestCandid"
                 val didFile = createDidFile(projectDir.root, didName, "src", "integTest", "candid")
-                val ktFile = Paths.get(projectDir.root.canonicalPath, "build/$CANDIDKT_TASK_DESTINATION_PREFIX/integTest", "${didName}.did.kt").toFile()
+                val ktFile = Paths.get(projectDir.root.canonicalPath, "build/$CANDID_DESTINATION_PREFIX_KOTLIN/integTest", "${didName}.did.kt").toFile()
                 buildFile.appendText("""
                     candid {
                         sourceSets {

--- a/src/test/kotlin/com/github/seniorjoinu/candid/plugin/CandidKtPluginSpec.kt
+++ b/src/test/kotlin/com/github/seniorjoinu/candid/plugin/CandidKtPluginSpec.kt
@@ -32,6 +32,11 @@ class CandidKtPluginSpec : FreeSpec({
                 plugins {
                     id 'com.github.seniorjoinu.candid'
                 }
+                candid {
+                    sourceSets {
+                        test
+                    }
+                }
             """.trimIndent())
             buildFile.appendText(System.lineSeparator())
             "positive executing 'gradle tasks'" - {

--- a/src/test/kotlin/com/github/seniorjoinu/candid/plugin/CandidKtPluginTest.kt
+++ b/src/test/kotlin/com/github/seniorjoinu/candid/plugin/CandidKtPluginTest.kt
@@ -14,6 +14,6 @@ class CandidKtPluginTest {
         project.gradle.startParameter.isOffline = true
 
         project.pluginManager.apply("com.github.seniorjoinu.candid")
-        assert(project.tasks.getByName(CANDIDKT_TASK_NAME) is CandidKtTask)
+        assert(project.tasks.getByName(CANDID_TASK_NAME) is CandidKtTask)
     }
 }


### PR DESCRIPTION
Apart from this change, I would also like to discuss the usage of terms `candid` vs. `candidKt`:

Currently we have (0) ...
- `const val CANDIDKT_EXTENSION_NAME = "candid"`
- `const val CANDIDKT_GROUP_NAME = "candid"`
- `const val CANDIDKT_TASK_NAME = "generateCandidKt"`

It should be either (1) ...
- `const val CANDIDKT_EXTENSION_NAME = "candid"`
- `const val CANDIDKT_GROUP_NAME = "candid"`
- `const val CANDIDKT_TASK_NAME = "generateCandid"`

... or a combination of `candid` and `kt` like (2) ...
- `const val CANDIDKT_EXTENSION_NAME = "candidkt"`
- `const val CANDIDKT_GROUP_NAME = "candidkt"`
- `const val CANDIDKT_TASK_NAME = "generateCandidKt"`

I'm in favor of (1); thoughts/concerns?